### PR TITLE
Move dbfile.json to Appdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ static/js/camerawork.js
 engines/
 downloads/
 out/
-dbfile.json
 
 # Ignore builds
 dist

--- a/dbfile.json
+++ b/dbfile.json
@@ -1,1 +1,0 @@
-{"version":"1","engineSrc":"ffm-backend.web.app","engine0":"C:\\Users\\erric\\Desktop\\Kade Engine","engine1":"C:\\Users\\erric\\Desktop\\Psych Eng"}

--- a/src/Database.js
+++ b/src/Database.js
@@ -1,24 +1,32 @@
 const fs = require('fs');
 const path = require('path');
+const { app } = require('electron')
+
+// Create AppData folder
+const appDataPath = path.join(app.getPath('appData'), 'FNF Launcher')
+
+if (!fs.existsSync(appDataPath)) {
+    fs.mkdirSync(appDataPath, { recursive: true });
+}
 
 // Create database if not existing
-if (!fs.existsSync(path.join(__dirname, '../', 'dbfile.json'))) {
-    fs.writeFileSync(path.join(__dirname, '../', 'dbfile.json'),JSON.stringify({"version": "1"}));
+if (!fs.existsSync(path.join(appDataPath, 'dbfile.json'))) {
+    fs.writeFileSync(path.join(appDataPath, 'dbfile.json'),JSON.stringify({"version": "1"}));
 }
 
 async function dbWriteValue(key, value) {
-    var db = JSON.parse(fs.readFileSync(path.join(__dirname, '../', 'dbfile.json'), 'utf8'));
+    var db = JSON.parse(fs.readFileSync(path.join(appDataPath, 'dbfile.json'), 'utf8'));
     db[key] = value;
-    fs.writeFileSync(path.join(__dirname, '../', 'dbfile.json'), JSON.stringify(db));
+    fs.writeFileSync(path.join(appDataPath, 'dbfile.json'), JSON.stringify(db));
 }
 
 function dbReadValue(key) {
-    var db = JSON.parse(fs.readFileSync(path.join(__dirname, '../', 'dbfile.json'), 'utf8'));
+    var db = JSON.parse(fs.readFileSync(path.join(appDataPath, 'dbfile.json'), 'utf8'));
     return db[key];
 }
 
 function dbGetAllEngines() {
-    var db = JSON.parse(fs.readFileSync(path.join(__dirname, '../', 'dbfile.json'), 'utf8'));
+    var db = JSON.parse(fs.readFileSync(path.join(appDataPath, 'dbfile.json'), 'utf8'));
     var engines = [];
     for (var key in db) {
         if (key.startsWith('engine') && key.startsWith('engineSrc') == false) {
@@ -37,9 +45,9 @@ function dbGetAllEngines() {
 }
 
 function dbDeleteValue(key) {
-    var db = JSON.parse(fs.readFileSync(path.join(__dirname, '../', 'dbfile.json'), 'utf8'));
+    var db = JSON.parse(fs.readFileSync(path.join(appDataPath, 'dbfile.json'), 'utf8'));
     delete db[key];
-    fs.writeFileSync(path.join(__dirname, '../', 'dbfile.json'), JSON.stringify(db));
+    fs.writeFileSync(path.join(appDataPath, 'dbfile.json'), JSON.stringify(db));
 }
 
 if (dbReadValue('engineSrc') == null || dbReadValue('engineSrc') == undefined) {
@@ -50,5 +58,6 @@ module.exports = {
     dbWriteValue: dbWriteValue,
     dbReadValue: dbReadValue,
     dbGetAllEngines: dbGetAllEngines,
-    dbDeleteValue: dbDeleteValue
+    dbDeleteValue: dbDeleteValue,
+    appDataPath: appDataPath
 };

--- a/src/Main.js
+++ b/src/Main.js
@@ -28,14 +28,7 @@ const e = require('express');
 const move = require('fs-move');
 const { title } = require('process');
 const { pathToFileURL } = require('url');
-const { dbDeleteValue, dbGetAllEngines, dbReadValue, dbWriteValue } = require('./Database');
-
-// Create AppData (for the logs)
-var appDataPath = app.getPath('appData') + '\\FNF Launcher';
-
-if (!fs.existsSync(appDataPath)) {
-    fs.mkdirSync(appDataPath, { recursive: true });
-}
+const { dbDeleteValue, dbGetAllEngines, dbReadValue, dbWriteValue, appDataPath } = require('./Database');
 
 // Migrate 1.4 engines to 1.5
 if (fs.existsSync(path.join(__dirname, '../', 'engines'))) {


### PR DESCRIPTION
it's as shrimple as that

this is done since electron packages dbfile.json into its app.asar, which means it cant be written to. this issue was only present in builds and NOT when doing 'yarn test'

for future reference: this same issue will occur for anything that uses __dirname, as __dirname links to inside the app.asar, after this PR the only thing that'll still be broken from this is 1.4 > 1.5 engine migration.